### PR TITLE
fix: slice pasted string in order to match verifcation code length

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -140,7 +140,7 @@ const ReactInputVerificationCode = ({
       if (!pastedString) return;
 
       const isNumber = !Number.isNaN(+pastedString);
-      if (isNumber) setValue(pastedString.split(''));
+      if (isNumber) setValue(pastedString.split('').slice(0, length));
     };
 
     codeInput.addEventListener('paste', onPaste);


### PR DESCRIPTION
I believe we should slice pasted string in order to match verifcation code length . 
Also, this fixes the issue of onCompleted is not being triggered when pasted string length is bigger then expected verifcation code length.